### PR TITLE
Updated to fix a windows specific build issue that was preventing some users from building

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -2,7 +2,7 @@
 const open = require('open')
 const { exec, spawn } = require('child_process')
 exec('npx webpack --mode="development"', () => {
-    spawn('npx', [ 'webpack', '--watch', '--mode="development"' ], { stdio: 'inherit' });
+    spawn(/^win/.test(process.platform) ? 'npx.cmd' : 'npx', [ 'webpack', '--watch', '--mode="development"' ], { stdio: 'inherit' });
     open('./public/index.html')
     console.log('Watching for changes in "./src"')
 })


### PR DESCRIPTION
Users would attempt to npm run start and get the error:

RR-Creating-a-Photo-Diary> npm run start

```
> 7.1.2-activity@1.0.0 start
> node ./bin

Watching for changes in "./src"
node:events:498
      throw er; // Unhandled 'error' event
      ^

Error: spawn npx ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)
    at onErrorNT (node:internal/child_process:478:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npx',
  path: 'npx',
  spawnargs: [ 'webpack', '--watch', '--mode="development"' ]
}
```

this can be fixed by modifying the command when run in a windows process. 